### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: php
 php:
   - 7.1
-  
+  - 7.2
+  - 7.3
+cache:
+  directories:
+    - $HOME/.composer/cache
+install:
+  - composer install
+script:
+  - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ cache:
 install:
   - composer install
 script:
-  - phpunit
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,20 @@
     "homepage": "https://github.com/Headoo/mailcheck",
     "keywords": ["mailcheck", "api", "bundle", "domain"],
     "authors": [{
-          "name": "Headoo"
+        "name": "Headoo"
        }
     ],
     "require": {
-          "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-intl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.2"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {"Mailcheck\\": "src/Mailcheck"}
+    },
+    "autoload-dev": {
+        "psr-4": {"Mailcheck\\Tests\\": "tests"}
     }
 }

--- a/src/Mailcheck/Mailcheck.php
+++ b/src/Mailcheck/Mailcheck.php
@@ -10,15 +10,15 @@ namespace Mailcheck;
  * Copyright (c) 2013 Headoo
  *
  * Licensed under the MIT License.
- * 
+ *
  * v 1.2
- * 
+ *
  * Free api : http://headoo.com/api/mailcheck/suggest/
  */
 
 /**
  * php port of https://github.com/Kicksend/mailcheck
- * 
+ *
  * Mailcheck https://github.com/Kicksend/mailcheck
  * Author
  * Derrick Ko (@derrickko)
@@ -95,7 +95,7 @@ class Mailcheck
         foreach ($domains as $domain) {
             $this->popularDomains[] = $domain;
         }
-    
+
         return $this;
     }
 
@@ -106,7 +106,7 @@ class Mailcheck
     public function setMistakenDomains($domains)
     {
         $this->popularDomains = $domains;
-    
+
         return $this;
     }
 
@@ -185,7 +185,7 @@ class Mailcheck
         }
 
         $closestDomain = $this->findClosest($emailParts->host, $this->popularDomains);
-        
+
         if ($closestDomain and $closestDomain != $emailParts->host) {
             // The email address closely matches one of the supplied domains; return a suggestion
             if ($this->debug) {
@@ -216,7 +216,7 @@ class Mailcheck
                 return $this->suggest($address);
             }
         }
-        
+
         if (isset($emailParts->tld) and (isset($this->mistakenTlds[$emailParts->tld]))) {
             if ($this->debug) {
                 echo "case #4" . PHP_EOL;
@@ -238,7 +238,7 @@ class Mailcheck
      */
     public function parseEmailAddress($address)
     {
-        /* We do not use imap_rfc822_parse_adrlist because imap_rfc822_parse_adrlist sanitize email and we don't want sanitization now. 
+        /* We do not use imap_rfc822_parse_adrlist because imap_rfc822_parse_adrlist sanitize email and we don't want sanitization now.
          * Sanitazation will be done in suggest function
          */
         $exploded = explode("@", $address, 2);
@@ -246,9 +246,9 @@ class Mailcheck
         if (!isset($exploded[1])) {
             $parsed["host"] = "";
         } else {
-            $parsed["host"] = idn_to_utf8($exploded[1]);
-        
-            $exploded = explode(".", $parsed["host"], 2);        
+            $parsed["host"] = idn_to_utf8($exploded[1], 0, INTL_IDNA_VARIANT_UTS46);
+
+            $exploded = explode(".", $parsed["host"], 2);
             if (isset($exploded[1])) {
                 $parsed["label"] = $exploded[0];
                 $parsed["tld"] = $exploded[1];
@@ -325,8 +325,8 @@ class Mailcheck
 
    /**
     * Not exactly closely related to Mailcheck, this function can find a bad email address in an delivery failure email body.
-    * You can call this function with 
-    * - a body or 
+    * You can call this function with
+    * - a body or
     * - an imap stream and a message number.
     *
     * @param $imapStream
@@ -364,7 +364,7 @@ class Mailcheck
     {
         $needle = "X-Failed-Recipients";
         $lines = preg_split('/\r\n|\r|\n/', $header);
-    
+
         foreach ($lines as $line) {
             $exploded = explode(":", $line, 2);
             if (stripos(trim($exploded[0]), $needle) !== false) {
@@ -388,7 +388,7 @@ class Mailcheck
     {
         $body = imap_utf8($body);
         $body = quoted_printable_decode($body);
-        $body = trim($body); 
+        $body = trim($body);
         $body = preg_replace('/\s+|[^a-zA-Z0-9-_@.\+\'"]+/', ' ', $body);
 
         $exploded = explode(' ', $body);

--- a/tests/MailcheckTest.php
+++ b/tests/MailcheckTest.php
@@ -7,40 +7,41 @@ use PHPUnit\Framework\TestCase;
 
 class MailcheckTest extends TestCase
 {
-	public function testSuggest()
+	public function suggestDataProvider()
 	{
-		require_once(__DIR__."/../src/Mailcheck/Mailcheck.php");
-		
-		$tests = [
-			'test@me.com' => 'test@me.com',
-			'test@me.com' => 'test@me.com',
-			'test@gooooogle.con' => 'test@gooooogle.com',
-			'test@gooooogle.com' => 'test@google.com',
-			'test' => false,
-			'test@google' => 'test@google.com',
-			'test@gmail.fr' => 'test@gmail.com',
-			'test@google.co' => 'test@google.com',
-			'test@google.c' => 'test@google.com',
-			'test@havasww.fr' => 'test@havasww.fr',
-			'test@havasww.org' => 'test@havasww.org',
-			'test@havasww.com' => 'test@havasww.com',
-			'test@hotmail.fr' => 'test@hotmail.com',
-			'test@25@wanadoo.fr' => 'test@wanadoo.fr',
-			'test@bnpparisbas.com:' => 'test@bnpparisbas.com',
-			'toto@gmail.com' => 'toto@gmail.com',
-			'toto@gmailcom' => 'toto@gmail.com',
-			'toto@gmaicom' => 'toto@gmail.com',
-			'toto@gmaiĺcom' => 'toto@gmail.com',
-			'toto@xn--gmaicom-whb' => 'toto@gmail.com',
-            'toto@hotmailcom' => 'toto@hotmail.com'
-			];
+		return [
+			['test@me.com', 'test@me.com'],
+			['test@me.com', 'test@me.com'],
+			['test@gooooogle.con', 'test@gooooogle.com'],
+			['test@gooooogle.com', 'test@google.com'],
+			['test', false],
+			['test@google', 'test@google.com'],
+			['test@gmail.fr', 'test@gmail.com'],
+			['test@google.co', 'test@google.com'],
+			['test@google.c', 'test@google.com'],
+			['test@havasww.fr', 'test@havasww.fr'],
+			['test@havasww.org', 'test@havasww.org'],
+			['test@havasww.com', 'test@havasww.com'],
+			['test@hotmail.fr', 'test@hotmail.com'],
+			['test@25@wanadoo.fr', 'test@wanadoo.fr'],
+			['test@bnpparisbas.com:', 'test@bnpparisbas.com'],
+			['toto@gmail.com', 'toto@gmail.com'],
+			['toto@gmailcom', 'toto@gmail.com'],
+			['toto@gmaicom', 'toto@gmail.com'],
+			['toto@gmaiĺcom', 'toto@gmail.com'],
+			['toto@xn--gmaicom-whb', 'toto@gmail.com'],
+            ['toto@hotmailcom', 'toto@hotmail.com'],
+		];
+	}
 
+	/**
+	 * @dataProvider suggestDataProvider
+	 */
+	public function testSuggest($emailInput, $emailxpected)
+	{
 		$mailcheck = new Mailcheck\Mailcheck();
 		$mailcheck->setDebug(0);
-		
-		foreach ($tests as $emailInput => $emailxpected) 
-		{
-			$this->assertEquals($emailxpected, $mailcheck->suggest($emailInput));
-		}	
-	}	
+
+		$this->assertEquals($emailxpected, $mailcheck->suggest($emailInput));
+	}
 }


### PR DESCRIPTION
# Changed log
- Using data provider to collect the test cases.
- Set correct settings for `.travis.yml` setting.
- Add the `php-7.2`, and `php-7.3` tests during Travis CI build.
- The `$variant` argument is for `INTL_IDNA_VARIANT_2003` constraint inside `idn_to_utf8` function is deprecated since `php-7.2`, and using the `INTL_IDNA_VARIANT_UTS46` variant instead.

Please look at detailed description on [official function reference](http://php.net/manual/en/function.idn-to-utf8.php).
- Integrate the Codecov coverage result after Travis CI build is successful. 